### PR TITLE
mata: Remove audio.offload.disable property

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -28,7 +28,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     audio.offload.min.duration.secs=0 \
     vendor.voice.conc.fallbackpath="" \
     audio.offload.video=true \
-    audio.offload.disable=false \
     audio.deep_buffer.media=true \
     vendor.audio.av.streaming.offload.enable=false \
     vendor.audio.offload.track.enable=true \


### PR DESCRIPTION
* This property is inaccessible from vendor_prop.mk since it is defined
  on the system side of the world.
* The default value for this is false anyway.

Change-Id: I16a14d93bd3de2fd55560db328f6c08d8b718b17